### PR TITLE
Add sanity interruption assertion

### DIFF
--- a/src/test/java/org/elasticsearch/TestSecureSM.java
+++ b/src/test/java/org/elasticsearch/TestSecureSM.java
@@ -127,7 +127,8 @@ public class TestSecureSM extends TestCase {
     t2.start();
     t2.interrupt();
     t2.join();
-    // sibling was not able to muck with its other sibling
+    // sibling attempted to but was not able to muck with its other sibling
+    assertTrue(interrupted2.get());
     assertFalse(interrupted1.get());
     // but we are the parent and can terminate
     t1.interrupt();


### PR DESCRIPTION
This commit adds an assertion to the TestSecureSM#testNoModifySibling
test that sanity checks that the second child was actually interrupted
and therefore actually attempted to interrupt the first child.
