### PR TITLE
Tighten which classes can exit

### DIFF
--- a/src/test/java/org/elasticsearch/TestSecureSM.java
+++ b/src/test/java/org/elasticsearch/TestSecureSM.java
@@ -55,6 +55,16 @@ public class TestSecureSM extends TestCase {
       fail("did not hit expected exception");
     } catch (SecurityException expected) {}
   }
+
+  @Test
+  public void testClassCanExit() {
+    assertTrue(SecureSM.classCanExit("org.apache.maven.surefire.booter.CommandReader", SecureSM.TEST_RUNNER_PACKAGES));
+    assertTrue(SecureSM.classCanExit("com.carrotsearch.ant.tasks.junit4.slave.JvmExit", SecureSM.TEST_RUNNER_PACKAGES));
+    assertTrue(SecureSM.classCanExit("org.eclipse.jdt.internal.junit.runner.RemoteTestRunner", SecureSM.TEST_RUNNER_PACKAGES));
+    assertTrue(SecureSM.classCanExit("com.intellij.rt.execution.junit.JUnitStarter", SecureSM.TEST_RUNNER_PACKAGES));
+    assertTrue(SecureSM.classCanExit("org.elasticsearch.Foo", new String[]{"org.elasticsearch.Foo"}));
+    assertFalse(SecureSM.classCanExit("org.elasticsearch.Foo", new String[]{"org.elasticsearch.Bar"}));
+  }
   
   @Test
   public void testCreateThread() throws Exception {


### PR DESCRIPTION
Today a SecureSM security manager allows defining a list of packages that can exit the VM. However, today there are no restrictions on defining a package inside another JAR. This commit strengthens the ability to prevent exit by allowing construction of SecureSM to be done with a list of regular expressions (instead of a list of prefix names) that classes will be tested against. With this, a security manager can be installed that permits only exiting from an exact list of classes.
