### PR TITLE
JVM behavior is to cache forever when a security manager is installed…

### DIFF
--- a/src/main/java/org/elasticsearch/SecureSM.java
+++ b/src/main/java/org/elasticsearch/SecureSM.java
@@ -22,6 +22,7 @@ package org.elasticsearch;
 import java.security.AccessController;
 import java.security.Permission;
 import java.security.PrivilegedAction;
+import java.security.Security;
 import java.util.Objects;
 
 /**
@@ -62,6 +63,15 @@ import java.util.Objects;
  *         http://cs.oswego.edu/pipermail/concurrency-interest/2009-August/006508.html</a>
  */
 public class SecureSM extends SecurityManager {
+
+  /*
+   * JVM behavior is to cache forever when a security manager is installed, set default values for TCP load-balancing support.
+   * Must be set before first TCP connection!
+   */
+  static {
+    Security.setProperty("networkaddress.cache.ttl", "60");
+    Security.setProperty("networkaddress.cache.negative.ttl", "10");
+  }
 
   private final String[] classesThatCanExit;
 


### PR DESCRIPTION
…, set default values for TCP load-balancing support.

https://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html

```
networkaddress.cache.ttl
Specified in java.security to indicate the caching policy for successful name lookups from the name service.. The value is specified as integer to indicate the number of seconds to cache the successful lookup.
A value of -1 indicates "cache forever". The default behavior is to cache forever when a security manager is installed, and to cache for an implementation specific period of time, when a security manager is not installed.


networkaddress.cache.negative.ttl (default: 10)
Specified in java.security to indicate the caching policy for un-successful name lookups from the name service.. The value is specified as integer to indicate the number of seconds to cache the failure for un-successful lookups.
A value of 0 indicates "never cache". A value of -1 indicates "cache forever".
```